### PR TITLE
create util class for safely clearing console using git bash

### DIFF
--- a/src/Actions/ChooseGrazingField.cs
+++ b/src/Actions/ChooseGrazingField.cs
@@ -4,23 +4,26 @@ using Trestlebridge.Interfaces;
 using Trestlebridge.Models;
 using Trestlebridge.Models.Animals;
 
-namespace Trestlebridge.Actions {
-    public class ChooseGrazingField {
-        public static void CollectInput (Farm farm, IGrazing animal) {
-            Console.Clear();
+namespace Trestlebridge.Actions
+{
+    public class ChooseGrazingField
+    {
+        public static void CollectInput(Farm farm, IGrazing animal)
+        {
+            Utils.Clear();
 
             for (int i = 0; i < farm.GrazingFields.Count; i++)
             {
-                Console.WriteLine ($"{i + 1}. Grazing Field");
+                Console.WriteLine($"{i + 1}. Grazing Field");
             }
 
-            Console.WriteLine ();
+            Console.WriteLine();
 
             // How can I output the type of animal chosen here?
-            Console.WriteLine ($"Place the animal where?");
+            Console.WriteLine($"Place the animal where?");
 
-            Console.Write ("> ");
-            int choice = Int32.Parse(Console.ReadLine ());
+            Console.Write("> ");
+            int choice = Int32.Parse(Console.ReadLine());
 
             farm.GrazingFields[choice].AddResource(animal);
 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -7,9 +7,9 @@ namespace Trestlebridge
 {
     class Program
     {
-        static void DisplayBanner ()
+        static void DisplayBanner()
         {
-            Console.Clear();
+            Utils.Clear();
             Console.WriteLine();
             Console.WriteLine(@"
         +-++-++-++-++-++-++-++-++-++-++-++-++-+
@@ -23,7 +23,7 @@ namespace Trestlebridge
         static void Main(string[] args)
         {
             Console.ForegroundColor = ConsoleColor.White;
-			Console.BackgroundColor = ConsoleColor.DarkMagenta;
+            Console.BackgroundColor = ConsoleColor.DarkMagenta;
 
             Farm Trestlebridge = new Farm();
 

--- a/src/Utils.cs
+++ b/src/Utils.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Linq;
+
+namespace Trestlebridge
+{
+    public static class Utils
+    {
+        /* 
+        ** Git Bash, specifically, doesn't like dotnet telling it to clear the console.
+        ** If `Console.Clear()` throws an exception, we're making the assumption that it's Git Bash running on a windows machine.
+        ** We try explicitly running the clear.exe command. If for some reason that doesn't work,
+        ** the last resort is to print 100 empty lines to the console....
+        */
+        public static void Clear()
+        {
+            try
+            {
+                Console.Clear();
+            }
+            catch (Exception)
+            {
+                try
+                {
+                    var process = System.Diagnostics.Process.Start(@"C:\Program Files\Git\usr\bin\clear.exe");
+                    process.WaitForExit();
+                }
+                catch (Exception)
+                {
+                    Enumerable.Range(1, 100).ToList().ForEach(Console.WriteLine);
+                }
+            }
+        }
+    }
+}

--- a/src/Utils.cs
+++ b/src/Utils.cs
@@ -26,7 +26,10 @@ namespace Trestlebridge
                 }
                 catch (Exception)
                 {
-                    Enumerable.Range(1, 100).ToList().ForEach(Console.WriteLine);
+                    for (int i = 0; i < 100; i++)
+                    {
+                        Console.WriteLine();
+                    }
                 }
             }
         }


### PR DESCRIPTION
Handle IOException thrown when trying to clear the console when using Git Bash

It attempts in this order
- Call `Console.Clear()`
- Execute `clear.exe` at likely path on windows
- Prints 100 newlines

Also my linter insisted on fixing the Egyptian brackets....